### PR TITLE
ADD

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "IDX.aI.enableInlineCompletion": true,
+    "IDX.aI.enableCodebaseIndexing": true
+}

--- a/src/app/api/register/route.ts
+++ b/src/app/api/register/route.ts
@@ -1,22 +1,28 @@
+
 import { NextResponse, type NextRequest } from 'next/server';
-import type { ServiceMetadata, RegisteredService } from '@/types';
+import type { ServiceRegistrationApiPayload, RegisteredService } from '@/types';
 
 // In a real application, this would interact with a database or an external service.
 // For this example, we'll just simulate it.
 
 export async function POST(request: NextRequest) {
   try {
-    const body = await request.json() as ServiceMetadata & { token: string };
+    const body = await request.json() as ServiceRegistrationApiPayload;
 
     // Basic validation (more robust validation should be done)
-    if (!body.name || !body.port || !body.type || !body.publicUrl || !body.token) {
-      return NextResponse.json({ message: 'Missing required fields.' }, { status: 400 });
+    if (!body.name || !body.local_url || !body.type || !body.public_url || !body.token) {
+      return NextResponse.json({ message: 'Missing required fields (name, local_url, type, public_url, token).' }, { status: 400 });
     }
 
     const registeredService: RegisteredService = {
       id: crypto.randomUUID(), // Generate a unique ID for this registration
-      ...body,
-      localUrl: `http://localhost:${body.port}`,
+      name: body.name,
+      description: body.description,
+      local_url: body.local_url,
+      public_url: body.public_url,
+      domain: body.domain,
+      type: body.type,
+      token: body.token,
       createdAt: new Date().toISOString(),
     };
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,15 +1,35 @@
-export interface ServiceMetadata {
+
+// Represents the raw data from the form, including customType if 'other' is selected
+export interface ServiceFormInputValues {
   name: string;
   description: string;
-  port: number;
+  local_url: string; // Changed from port
   domain?: string;
-  type: 'website' | 'api' | 'game';
-  publicUrl: string;
+  type: 'website' | 'api' | 'game' | 'other';
+  customType?: string; // For 'other' type
+  publicUrl: string; // Field from form, will be mapped to public_url for API
 }
 
-export interface RegisteredService extends ServiceMetadata {
-  id: string; // Unique identifier for the registration
-  token: string; // Generated token
-  localUrl: string;
+// Represents the data structure sent to the /api/register endpoint
+export interface ServiceRegistrationApiPayload {
+  name: string;
+  description: string;
+  local_url: string; // As per API doc
+  domain?: string;
+  type: string; // Actual type string (e.g. 'website' or custom value)
+  public_url: string; // As per API doc
+  token: string;
+}
+
+// Represents the service data as returned by the API and used for display
+export interface RegisteredService {
+  id: string;
+  name: string;
+  description: string;
+  local_url: string; // As per API doc
+  public_url: string; // As per API doc
+  domain?: string;
+  type: string;
+  token: string;
   createdAt: string;
 }


### PR DESCRIPTION


---- PANDA NOTE DE DEV - API ----

POD (cœur & domaine) : localhost:9002
CLIENT (Créer un domaine & link au pod) : localhost:9003
BROWSER (motheur de recherche veneant du coeur) : localhost 9004

    UTILISER L'API
---------------------------------------------

1.Enregistrer un nouveau service
Description: Permet d'ajouter une nouvelle entrée de service au registre. Un token unique est généré et retourné pour chaque service enregistré. Méthode HTTP: POST
Chemin: /api/register
Corps de la requête (JSON):
{
          "name": "string",         // Nom du service (requis) [exemple : Mon Site]
          "description": "string",  // Description du service (requis) [exemple : Le meilleur site]
          "local_url": "string",    // URL locale du service (requis) [exemple : localhost:3630]
          "public_url": "string",   // URL publique du service (requis) [exemple : playit.[ID]:[PORT]]
          "domain": "string",       // Domaine personnalisé (doit être unique) (requis) [exemple : monsite.panda]
          "type": "string"          // Type de service (e.g., "website", "api", "game") (requis) [exemple : Hebergeur-Website]
          // Le token n'est PAS envoyé ici, il est généré par l'API
        }

---------------------------------------------

2. Rechercher des services * Description: Permet de rechercher des services enregistrés. Vous pouvez rechercher par nom, description, domaine ou type en utilisant un paramètre de requête. Si aucun paramètre n'est fourni, tous les services (sans le token) sont retournés. * Méthode HTTP: GET * Chemin: /api/search * Paramètres de requête: * q: La chaîne de recherche. La recherche est effectuée sur les champs name, description, domain et type [2]. * Exemple de chemin: http://localhost:9002/api/search?q=MonService * Réponse: Une liste d'objets service (excluant le champ token) correspondant aux critères de recherche, ou tous les services si q est absent.

exemple :

[{"id":"4872169e-867d-4820-bc97-a90d3daf8085","name":"MonNouveauSite","description":"Une description mise à jour par script Python (Header Auth)","local_url":"http://localhost:8080/unique/updated","public_url":"https://monnouveausite.com","domain":"site-1748861083.panda","type":"website","created_at":"2025-06-02T10:44:44.885Z"}]

---------------------------------------------

3.Mettre à jour un service
Description: Permet de modifier les informations d'un service existant en utilisant son ID. Nécessite le token associé au service pour l'authentification. Méthode HTTP: PUT
Chemin: /api/register/:id (où :id est l'ID du service à mettre à jour) Exemple de chemin: http://localhost:9002/api/register/votre_id_service Headers requis:
Authorization: Bearer votre_token_secret (Le token obtenu lors de l'enregistrement) [3] Content-Type: application/json
Corps de la requête (JSON): Un objet contenant les champs du service que vous souhaitez mettre à jour. Vous ne devez inclure que les champs à modifier. {
          "name": "string",         // Optionnel
          "description": "string",  // Optionnel
          "local_url": "string",    // Optionnel
          "public_url": "string",   // Optionnel
          "domain": "string",       // Optionnel (doit être unique parmi les autres services)
          "type": "string"          // Optionnel
          // Le token n'est PAS inclus ici, il est dans le header Authorization
        }

---------------------------------------------

4. Supprimer un service * Description: Permet de supprimer un service du registre en utilisant son ID. Nécessite le token associé au service pour l'authentification. * Méthode HTTP: DELETE * Chemin: /api/register/:id (où :id est l'ID du service à supprimer) * Exemple de chemin: http://localhost:9002/api/register/votre_id_service * Headers requis: * Authorization: Bearer votre_token_secret (Le token obtenu lors de l'enregistrement) [3] * Corps de la requête: Généralement pas de corps pour une requête DELETE avec authentification par header. * Réponse: Un message confirmant la suppression (ou un code 204 No Content) [3].

Gérer les requêtes OPTIONS (CORS)
Description: Utilisé par les navigateurs web pour vérifier les méthodes HTTP et les headers autorisés avant d'envoyer une requête réelle (processus CORS). Méthode HTTP: OPTIONS
Chemins: /api/register, /api/search, /api/register/:id Exemple de chemin: http://localhost:9002/api/register Headers requis: Aucun en particulier (dépend du navigateur). Réponse: Headers HTTP indiquant les méthodes et origines autorisées. Vous n'interagirez pas directement avec cet endpoint dans un script simple, il est géré automatiquement par les bibliothèques comme requests.

---------------------------------------------

NOTE PERSO ATTENTIONS - FAUT FAIRE LE MOYEN POUR QUE LE DOMAINE (monsite.panda) SOIT ACCESIBLE D'UNE MANIERRE OU D'UNE AUTRE, (par exemple un script qui fait un espèce de Proxi voir même un new navigateur ou jsp)